### PR TITLE
Fix: external links

### DIFF
--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -315,6 +315,10 @@ class MessageHistoryComponent
       })
   }
 
+  private messageTypeToProtocol(messageType: string) {
+    return messageType.slice(0, messageType.lastIndexOf("/"))
+  }
+
   viewMessage(message: Message) {
     switch (message.type) {
       case "https://didcomm.org/basicmessage/2.0/message":
@@ -385,13 +389,20 @@ class MessageHistoryComponent
                 "li",
                 m("span", [
                   `${disclosure["feature-type"]}: `,
-                  m("a", { href: disclosure.id, target: "_blank" }, [
-                    disclosure.id,
-                    m(
-                      "span.icon",
-                      m(`i.fas.fa-arrow-up-right-from-square.is-small`)
-                    ),
-                  ]),
+                  m(
+                    "a",
+                    {
+                      href: this.messageTypeToProtocol(disclosure.id),
+                      target: "_blank",
+                    },
+                    [
+                      disclosure.id,
+                      m(
+                        "span.icon",
+                        m(`i.fas.fa-arrow-up-right-from-square.is-small`)
+                      ),
+                    ]
+                  ),
                 ])
               )
             )

--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -385,7 +385,13 @@ class MessageHistoryComponent
                 "li",
                 m("span", [
                   `${disclosure["feature-type"]}: `,
-                  m("a", { href: disclosure.id }, disclosure.id),
+                  m("a", { href: disclosure.id, target: "_blank" }, [
+                    disclosure.id,
+                    m(
+                      "span.icon",
+                      m(`i.fas.fa-arrow-up-right-from-square.is-small`)
+                    ),
+                  ]),
                 ])
               )
             )
@@ -400,7 +406,10 @@ class MessageHistoryComponent
             class: "unhandled",
             inspectable: true,
           },
-          [m("a", { href: message.type }, message.type)]
+          m("a", { href: message.type, target: "_blank" }, [
+            message.type,
+            m("span.icon", m(`i.fas.fa-arrow-up-right-from-square.is-small`)),
+          ])
         )
     }
   }


### PR DESCRIPTION
- Opens protocol links from message discovery and problem reports in a new tab
- Added an icon to signify that it's an external link
- Strip off message type from URL in problem reports to link to the protocol page