### PR TITLE
chore: remove label from contact dialog

### DIFF
--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -158,21 +158,6 @@ class ContactListComponent
                     )
                   ),
                 ]),
-                m(".field", [
-                  m("label.label", "Label (optional)"),
-                  m(
-                    "div.control",
-                    m(
-                      'input.input[type=text][placeholder="Label for the contact"]',
-                      {
-                        oninput: (e: Event) =>
-                          (this.newContact.label = (
-                            e.target as HTMLInputElement
-                          ).value),
-                      }
-                    )
-                  ),
-                ]),
               ]),
               m("footer.modal-card-foot", [
                 m(


### PR DESCRIPTION
Since we are automatically negotiating user profiles, and the label doesn't do much unless the other party doesn't respond, let's remove the option to change the label from the "Add a contact" modal form.