### PR TITLE
fix: strip off message type on proper messages

### DIFF
--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -384,7 +384,7 @@ class MessageHistoryComponent
                   m(
                     "a",
                     {
-                      href: this.messageTypeToProtocol(disclosure.id),
+                      href: disclosure.id,
                       target: "_blank",
                     },
                     [
@@ -409,7 +409,7 @@ class MessageHistoryComponent
             class: "unhandled",
             inspectable: true,
           },
-          m("a", { href: message.type, target: "_blank" }, [
+          m("a", { href: this.messageTypeToProtocol(message.type), target: "_blank" }, [
             message.type,
             m("span.icon", m(`i.fas.fa-arrow-up-right-from-square.is-small`)),
           ])


### PR DESCRIPTION
The message disclosure messages were getting the version number stripped off instead of the unhandled messages getting the message type stripped off.