### PR TITLE
feat: add trust-ping to UI

### DIFF
--- a/src/pages/profile/message.ts
+++ b/src/pages/profile/message.ts
@@ -7,6 +7,7 @@ interface MessageCardAttrs {
   message: Message
   class?: "unhandled" | "info"
   inspectable?: boolean
+  hideBody?: boolean
 }
 
 export default class MessageCard implements m.ClassComponent<MessageCardAttrs> {
@@ -15,6 +16,7 @@ export default class MessageCard implements m.ClassComponent<MessageCardAttrs> {
   class?: "unhandled" | "info"
   status: "sent" | "received"
   inspectable?: boolean
+  hideBody?: boolean
   private isModalOpen: boolean = false
   private rawMessageData: string = ""
 
@@ -23,6 +25,7 @@ export default class MessageCard implements m.ClassComponent<MessageCardAttrs> {
     this.message = vnode.attrs.message
     this.class = vnode.attrs.class
     this.inspectable = vnode.attrs.inspectable
+    this.hideBody = vnode.attrs.hideBody
 
     this.status =
       this.message.raw?.from == agent.profile.did ? "sent" : "received"
@@ -69,39 +72,43 @@ export default class MessageCard implements m.ClassComponent<MessageCardAttrs> {
       m(".message-header", [
         this.viewMessageBoxHeader(this.header, this.message),
       ]),
-      m(
-        ".message-body",
-        {
-          style: {
-            display: "flex",
-            flexDirection: "column",
+      !this.hideBody &&
+        m(
+          ".message-body",
+          {
+            style: {
+              display: "flex",
+              flexDirection: "column",
+            },
           },
-        },
-        [
-          m("div", [
-            vnode.children,
-            this.inspectable &&
-              m(
-                "button.button.is-small",
-                {
-                  onclick: () => {
-                    this.isModalOpen = true
-                    this.rawMessageData = JSON.stringify(
-                      this.message.raw,
-                      null,
-                      2
-                    )
+          [
+            m("div", [
+              vnode.children,
+              this.inspectable &&
+                m(
+                  "button.button.is-small",
+                  {
+                    onclick: () => {
+                      this.isModalOpen = true
+                      this.rawMessageData = JSON.stringify(
+                        this.message.raw,
+                        null,
+                        2
+                      )
+                    },
+                    style: {
+                      marginTop: ".75rem",
+                      float: "right",
+                    },
                   },
-                  style: {
-                    marginTop: ".75rem",
-                    float: "right",
-                  },
-                },
-                [m("span.icon", m("i.fas.fa-plus")), m("span", "View Message")]
-              ),
-          ]),
-        ]
-      ),
+                  [
+                    m("span.icon", m("i.fas.fa-plus")),
+                    m("span", "View Message"),
+                  ]
+                ),
+            ]),
+          ]
+        ),
       this.isModalOpen &&
         m(".modal.is-active", [
           m(".modal-background", {

--- a/src/pages/profile/messaging.ts
+++ b/src/pages/profile/messaging.ts
@@ -400,6 +400,20 @@ class MessageHistoryComponent
             )
           )
         )
+      case "https://didcomm.org/trust-ping/2.0/ping":
+        return m(MessageCard, {
+          header: "Ping",
+          message,
+          inspectable: false,
+          hideBody: true,
+        })
+      case "https://didcomm.org/trust-ping/2.0/ping-response":
+        return m(MessageCard, {
+          header: "Pong",
+          message,
+          inspectable: false,
+          hideBody: true,
+        })
       default:
         return m(
           MessageCard,


### PR DESCRIPTION
Adds trust ping messages to the list of known message in the message view. Since there's no content, there's no need to show the message body underneath, and the log pane shows the full message as well if people want to see it.
![2023-10-06-152840_1381x547_scrot](https://github.com/decentralized-identity/didcomm-demo/assets/509363/f3227c75-3786-498f-8946-fa6522b8c1b2)
